### PR TITLE
feat: add favourites support

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,6 +31,7 @@ import SocialMedia from './components/SocialMedia';
 import AdminDashboard from './components/AdminDashboard';
 import Contact from './components/Contact';
 import AllCategory from './components/allCategory';
+import Favorites from './components/Favorites';
 
 function App() {
   const [backendReady, setBackendReady] = useState(false);
@@ -107,8 +108,9 @@ function App() {
          <Route path="/addConfi" element={<AddConfi />} />
          <Route path="/subcategory/:id" element={<FilterSubategory />} />
          <Route path="/list/:itemId" element={<List />} />
-         <Route path="/SocialMedia" element={<SocialMedia />} />
-         <Route path="/contact" element={<Contact />} />
+        <Route path="/SocialMedia" element={<SocialMedia />} />
+        <Route path="/contact" element={<Contact />} />
+        <Route path="/favorites" element={<Favorites />} />
       </Routes>
     </Router>
   );

--- a/src/components/Favorites.jsx
+++ b/src/components/Favorites.jsx
@@ -1,0 +1,43 @@
+import { Link } from 'react-router-dom';
+import { useFavorites } from '../context/FavoritesContext';
+
+const Favorites = () => {
+  const { favorites, removeFavorite } = useFavorites();
+
+  if (favorites.length === 0) {
+    return <p className="p-4 text-center">No favourites yet.</p>;
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto p-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {favorites.map((item) => (
+        <div key={item.id} className="border rounded shadow-sm p-4 flex flex-col">
+          <img
+            src={item.images?.[0]}
+            alt={item.title}
+            className="h-40 w-full object-cover rounded mb-2"
+          />
+          <h3 className="text-lg font-semibold mb-1">{item.title}</h3>
+          <p className="text-sm text-gray-600 mb-2">{item.price} USD / night</p>
+          <div className="mt-auto flex justify-between items-center">
+            <Link
+              to={`/listing/${item.id}`}
+              className="text-blue-500 hover:underline text-sm"
+            >
+              View Details
+            </Link>
+            <button
+              onClick={() => removeFavorite(item.id)}
+              className="text-xs text-red-500 hover:underline"
+            >
+              Remove
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default Favorites;
+

--- a/src/components/ListingDetails.jsx
+++ b/src/components/ListingDetails.jsx
@@ -43,19 +43,23 @@ const ListingDetails = () => {
         {isFavorite ? 'Remove from Favourites' : 'Add to Favourites'}
       </button>
 
-      {/* Render Images */}
-      <div className="grid grid-cols-1 gap-4">
-        {listing.images.map((image, index) => (
-          <img
-            key={index}
-            src={image}
-            alt={`Listing image ${index + 1}`}
-            className="w-full h-96 object-cover rounded"
-          />
-        ))}
+        {/* Render Images */}
+        {listing.images?.length ? (
+          <div className="grid grid-cols-1 gap-4">
+            {listing.images.map((image, index) => (
+              <img
+                key={index}
+                src={image}
+                alt={`Listing image ${index + 1}`}
+                className="w-full h-96 object-cover rounded"
+              />
+            ))}
+          </div>
+        ) : (
+          <p className="text-sm text-gray-500">No images available.</p>
+        )}
       </div>
-    </div>
-  );
-};
+    );
+  };
 
 export default ListingDetails;

--- a/src/components/ListingDetails.jsx
+++ b/src/components/ListingDetails.jsx
@@ -1,10 +1,12 @@
 import { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import api from '../api';
+import { useFavorites } from '../context/FavoritesContext';
 
 const ListingDetails = () => {
   const [listing, setListing] = useState(null);
-  const { id } = useParams(); 
+  const { id } = useParams();
+  const { favorites, addFavorite, removeFavorite } = useFavorites();
 
   useEffect(() => {
     const fetchListing = async () => {
@@ -23,21 +25,32 @@ const ListingDetails = () => {
     return <div>Loading...</div>;
   }
 
+  const isFavorite = favorites.some((item) => item.id === listing.id);
+
   return (
-    <div className="listing-details">
-      <h2>{listing.title}</h2>
-      <p>{listing.description}</p>
-      <p>{listing.price} USD / night</p>
-      <p>{listing.location}</p>
+    <div className="max-w-3xl mx-auto p-4">
+      <h2 className="text-2xl font-bold mb-2">{listing.title}</h2>
+      <p className="mb-2 text-gray-700">{listing.description}</p>
+      <p className="mb-1 font-semibold">{listing.price} USD / night</p>
+      <p className="mb-4 text-sm text-gray-500">{listing.location}</p>
+
+      <button
+        onClick={() =>
+          isFavorite ? removeFavorite(listing.id) : addFavorite(listing)
+        }
+        className="mb-4 px-4 py-2 rounded bg-pink-500 text-white hover:bg-pink-600"
+      >
+        {isFavorite ? 'Remove from Favourites' : 'Add to Favourites'}
+      </button>
 
       {/* Render Images */}
-      <div className="images">
+      <div className="grid grid-cols-1 gap-4">
         {listing.images.map((image, index) => (
           <img
             key={index}
             src={image}
             alt={`Listing image ${index + 1}`}
-            className="w-full h-96 object-cover mb-4"
+            className="w-full h-96 object-cover rounded"
           />
         ))}
       </div>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,19 +1,23 @@
 import { FaFacebookMessenger } from 'react-icons/fa';
+import { Link } from 'react-router-dom';
 
 const Navbar = () => {
   return (
     <div className="flex justify-between items-center p-3 sticky top-0 bg-white z-10">
-      <h1 className="text-xl font-bold flex items-center gap-2">
-        SK Cards
-      </h1>
-      <a
-        href="https://wa.me/919372333633?text=Hi%2C%20I%20would%20like%20to%20make%20an%20enquiry"
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-2xl text-green-600"
-      >
-        <FaFacebookMessenger />       
-      </a>
+      <h1 className="text-xl font-bold flex items-center gap-2">SK Cards</h1>
+      <div className="flex items-center gap-4">
+        <Link to="/favorites" className="text-sm text-gray-700 hover:underline">
+          Favourites
+        </Link>
+        <a
+          href="https://wa.me/919372333633?text=Hi%2C%20I%20would%20like%20to%20make%20an%20enquiry"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-2xl text-green-600"
+        >
+          <FaFacebookMessenger />
+        </a>
+      </div>
     </div>
   );
 };

--- a/src/context/FavoritesContext.jsx
+++ b/src/context/FavoritesContext.jsx
@@ -1,0 +1,44 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+
+const FavoritesContext = createContext();
+
+export const FavoritesProvider = ({ children }) => {
+  const [favorites, setFavorites] = useState([]);
+
+  // Load from localStorage on mount
+  useEffect(() => {
+    const stored = localStorage.getItem('favorites');
+    if (stored) {
+      try {
+        setFavorites(JSON.parse(stored));
+      } catch (_) {
+        // ignore parse errors
+      }
+    }
+  }, []);
+
+  // Persist to localStorage whenever it changes
+  useEffect(() => {
+    localStorage.setItem('favorites', JSON.stringify(favorites));
+  }, [favorites]);
+
+  const addFavorite = (listing) => {
+    setFavorites((prev) => {
+      if (prev.find((item) => item.id === listing.id)) return prev;
+      return [...prev, listing];
+    });
+  };
+
+  const removeFavorite = (id) => {
+    setFavorites((prev) => prev.filter((item) => item.id !== id));
+  };
+
+  return (
+    <FavoritesContext.Provider value={{ favorites, addFavorite, removeFavorite }}>
+      {children}
+    </FavoritesContext.Provider>
+  );
+};
+
+export const useFavorites = () => useContext(FavoritesContext);
+

--- a/src/context/FavoritesContext.jsx
+++ b/src/context/FavoritesContext.jsx
@@ -3,24 +3,28 @@ import { createContext, useContext, useEffect, useState } from 'react';
 const FavoritesContext = createContext();
 
 export const FavoritesProvider = ({ children }) => {
-  const [favorites, setFavorites] = useState([]);
+    const [favorites, setFavorites] = useState([]);
 
-  // Load from localStorage on mount
-  useEffect(() => {
-    const stored = localStorage.getItem('favorites');
-    if (stored) {
-      try {
-        setFavorites(JSON.parse(stored));
-      } catch (_) {
-        // ignore parse errors
+    // Load from localStorage on mount
+    useEffect(() => {
+      if (typeof window !== 'undefined') {
+        const stored = window.localStorage.getItem('favorites');
+        if (stored) {
+          try {
+            setFavorites(JSON.parse(stored));
+          } catch (_) {
+            // ignore parse errors
+          }
+        }
       }
-    }
-  }, []);
+    }, []);
 
-  // Persist to localStorage whenever it changes
-  useEffect(() => {
-    localStorage.setItem('favorites', JSON.stringify(favorites));
-  }, [favorites]);
+    // Persist to localStorage whenever it changes
+    useEffect(() => {
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem('favorites', JSON.stringify(favorites));
+      }
+    }, [favorites]);
 
   const addFavorite = (listing) => {
     setFavorites((prev) => {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,10 +2,13 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
+import { FavoritesProvider } from './context/FavoritesContext';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <FavoritesProvider>
+      <App />
+    </FavoritesProvider>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
## Summary
- add Favorites context to persist favourite listings
- include favourites page and navigation link
- allow adding/removing listings from favourites

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a03c4bc5dc8322944367641ca5527d